### PR TITLE
fix: AlterindonesiaRestController::show method throw BadMethodCallException

### DIFF
--- a/src/Controllers/AlterindonesiaRestController.php
+++ b/src/Controllers/AlterindonesiaRestController.php
@@ -82,7 +82,11 @@ class AlterindonesiaRestController extends AlterindonesiaBaseController
         }
 
         // return success response
-        return $this->responseSuccess($result["message"], $result["data"], Response::HTTP_OK, $result["resource"]);
+        return $this->responseSuccess(
+            $result["message"],
+            new $result["resource"]($result["data"]),
+            Response::HTTP_OK
+        );
     }
 
     /**


### PR DESCRIPTION
This PR fix the `show` method of `AlterindonesiaRestController` throwing `BadMethodCallException`

Before:
![image](https://user-images.githubusercontent.com/2605235/224463519-1f79bf5d-eb9f-4dd8-a090-bdd56899c428.png)

After:
![image](https://user-images.githubusercontent.com/2605235/224463542-62da2986-2cab-41b8-8ba7-e1ed28e246ac.png)
